### PR TITLE
Check if ip6:XXX is actually an IPv6 address

### DIFF
--- a/mechanisms.js
+++ b/mechanisms.js
@@ -123,7 +123,7 @@ module.exports = {
 				throw new MechanismError(`Missing or blank mandatory network specification for the 'ip6' mechanism.`, 'error');
 			}
 
-			if (!ipaddr.isValid(ip)) {
+			if (!ipaddr.IPv6.isValid(ip)) {
 				throw new MechanismError(`Invalid IPv6 address: '${ip}'`, 'error');
 			}
 

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,17 @@ test('Invalid ip6 fails', t => {
 	]);
 });
 
+test('IPv4 is not an IPv6', t => {
+	const m = [];
+	s.parseTerm('ip6:127.0.0.1', m);
+	t.deepEqual(m, [
+		{
+			message: `Invalid IPv6 address: '127.0.0.1'`,
+			type: 'error'
+		}
+	]);
+});
+
 test('Invalid ip6 CIDR fails', t => {
 	const m = [];
 	s.parseTerm('ip6:::1/720', m);


### PR DESCRIPTION
Thought it safer to use the already included ipaddr.js to check if ip6 entries are **actually** IPv6 addresses as currently it doesn't discriminate against v4 addresses.